### PR TITLE
Bugfix in job page after include a new job

### DIFF
--- a/src/components/molecules/formComponents/Select/Select.tsx
+++ b/src/components/molecules/formComponents/Select/Select.tsx
@@ -2,7 +2,7 @@ import { forwardRef, RefObject, SelectHTMLAttributes } from "react";
 import ErrorMessageForm from "@atoms/ErrorMessageForm";
 
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
-  options: { id: string; value: string }[];
+  options: { id: number; value: string }[];
   errors: {};
 }
 

--- a/src/components/organisms/forms/JobPostForm/JobPostForm.stories.tsx
+++ b/src/components/organisms/forms/JobPostForm/JobPostForm.stories.tsx
@@ -7,30 +7,29 @@ export default {
   component: JobPostForm,
 } as ComponentMeta<typeof JobPostForm>;
 
-const stackAllOptions = {
-  id: "1",
-  name: "Stack Group",
-  stack: ["stack1", "stack2", "stack3"],
-};
-const curatorData = {
-  id: "1",
-  name: "Curator Name",
-};
-const refreshStackAllOptions = () => {};
-const requisitesOptions = [{ id: "1", value: "Requisite 1" }];
-const refreshRequisitesOptions = () => {};
-const refreshCompanyAutoComplete = () => {};
+const stackAllOptions = [{ id: 1, name: "stackName", stack: ["react"] }];
+const requisitesOptions = [{ id: 1, value: "RequisiteValue" }];
+const curatorData = { id: 1, name: "CuratorName" };
+const companiesAllOptions = [
+  {
+    id: 1,
+    name: "CompanyName",
+    logo: "CompanyLogo",
+    webSite: "CompanyWebSite",
+    linkedin: "CompanyLinkedIn",
+  },
+];
 
 const Template: ComponentStory<typeof JobPostForm> = (args) => (
   <JobPostForm
-    stackAllOptions={[stackAllOptions]}
-    curatorData={curatorData}
-    refreshStackAllOptions={refreshStackAllOptions}
+    stackAllOptions={stackAllOptions}
     requisitesOptions={requisitesOptions}
-    refreshRequisitesOptions={refreshRequisitesOptions}
-    createJob={async () => ""}
-    refreshCompanyAutoComplete={refreshCompanyAutoComplete}
-    companiesAllOptions={[]}
+    curatorData={curatorData}
+    refreshStackAllOptions={() => {}}
+    refreshRequisitesOptions={() => {}}
+    refreshCompanyAutoComplete={() => {}}
+    createJob={Promise.resolve}
+    companiesAllOptions={companiesAllOptions}
   />
 );
 

--- a/src/components/organisms/forms/JobPostForm/JobPostForm.test.tsx
+++ b/src/components/organisms/forms/JobPostForm/JobPostForm.test.tsx
@@ -2,10 +2,34 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import JobPostForm from ".";
 import "@testing-library/jest-dom";
 
+const stackAllOptions = [{ id: 1, name: "stackName", stack: ["react"] }];
+const requisitesOptions = [{ id: 1, value: "RequisiteValue" }];
+const curatorData = { id: 1, name: "CuratorName" };
+const companiesAllOptions = [
+  {
+    id: 1,
+    name: "CompanyName",
+    logo: "CompanyLogo",
+    webSite: "CompanyWebSite",
+    linkedin: "CompanyLinkedIn",
+  },
+];
+
 describe("organism > JobPostForm", () => {
   it("it show TopContainer", () => {
-    render(<JobPostForm />);
+    render(
+      <JobPostForm
+        stackAllOptions={stackAllOptions}
+        requisitesOptions={requisitesOptions}
+        curatorData={curatorData}
+        refreshStackAllOptions={() => {}}
+        refreshRequisitesOptions={() => {}}
+        refreshCompanyAutoComplete={() => {}}
+        createJob={Promise.resolve}
+        companiesAllOptions={companiesAllOptions}
+      />
+    );
 
-    expect(screen.getByText("JobPostForm")).toBeInTheDocument();
+    expect(screen.getByText("Cadastrar Vaga")).toBeInTheDocument();
   });
 });

--- a/src/components/organisms/forms/JobPostForm/JobPostForm.tsx
+++ b/src/components/organisms/forms/JobPostForm/JobPostForm.tsx
@@ -18,7 +18,7 @@ import PostJobNewData from "@molecules/formComponents/PostJobNewData";
 const schema = yup
   .object({
     title: yup.string().required(),
-    company: yup.string().required(),
+    company: yup.number().required(),
     description: yup.string().required(),
     location: yup.string().required(),
     requisites: yup.array().required(),
@@ -29,9 +29,9 @@ const schema = yup
   .required();
 
 interface JobPostFormProps {
-  stackAllOptions: { id: string; name: string; stack: string[] }[];
-  requisitesOptions: { id: string; value: string }[];
-  curatorData: { id: string; name: string };
+  stackAllOptions: { id: number; name: string; stack: string[] }[];
+  requisitesOptions: { id: number; value: string }[];
+  curatorData: { id: number; name: string };
   refreshStackAllOptions(): void;
   refreshRequisitesOptions(): void;
   refreshCompanyAutoComplete(): void;
@@ -85,12 +85,12 @@ const JobPostForm = ({
       return;
     }
 
-    const indicatedBy = ""; //This come from outside the form - and it is optional
+    const indicatedBy = 1; //This come from outside the form - and it is optional
     const now = new Date();
 
     const jobPost: IJob = {
       title,
-      company: Number(company),
+      company,
       description,
       location,
       requisites,
@@ -100,8 +100,8 @@ const JobPostForm = ({
       status: "open",
       createAt: now,
       modifiedAt: now,
-      curator: Number(curatorData.id),
-      indicatedBy: Number(indicatedBy),
+      curator: curatorData.id,
+      indicatedBy,
       blob: `${title} ${company} ${
         curatorData.name
       } ${now.getFullYear()} ${now.getMonth()} ${now.getDay()}`,

--- a/src/components/organisms/forms/JobPostForm/JobPostForm.tsx
+++ b/src/components/organisms/forms/JobPostForm/JobPostForm.tsx
@@ -7,32 +7,13 @@ import * as yup from "yup";
 import styles from "./JobPostForm.module.css";
 
 import { ICompany } from "@services/company";
+import { IJob } from "@services/job";
 
 import TextInput from "@molecules/formComponents/TextInput";
 import TextArea from "@molecules/formComponents/TextArea";
 import Select from "@molecules/formComponents/Select";
 import UserStackSelector from "@organisms/UserStackSelector";
 import PostJobNewData from "@molecules/formComponents/PostJobNewData";
-
-interface IFormInputs {
-  company: string;
-  description: string;
-  location: string;
-  requisites: string[];
-  stack: string[];
-  title: string;
-  url: string;
-  source: string;
-}
-
-interface IPostJobData extends IFormInputs {
-  status: string;
-  createAt: Date;
-  modifiedAt: Date;
-  curator: string;
-  indicatedBy: string;
-  blob: string;
-}
 
 const schema = yup
   .object({
@@ -54,7 +35,7 @@ interface JobPostFormProps {
   refreshStackAllOptions(): void;
   refreshRequisitesOptions(): void;
   refreshCompanyAutoComplete(): void;
-  createJob(data: IPostJobData): Promise<string>;
+  createJob(data: IJob): Promise<string>;
   companiesAllOptions: ICompany[];
 }
 
@@ -83,11 +64,11 @@ const JobPostForm = ({
     formState: { errors },
     watch,
     control,
-  } = useForm<IFormInputs>({
+  } = useForm<Partial<IJob>>({
     resolver: yupResolver(schema),
   });
 
-  const onSubmit = async (data: IFormInputs) => {
+  const onSubmit = async (data: IJob) => {
     const {
       title,
       company,
@@ -107,9 +88,9 @@ const JobPostForm = ({
     const indicatedBy = ""; //This come from outside the form - and it is optional
     const now = new Date();
 
-    const jobPost = {
+    const jobPost: IJob = {
       title,
-      company,
+      company: Number(company),
       description,
       location,
       requisites,
@@ -119,8 +100,8 @@ const JobPostForm = ({
       status: "open",
       createAt: now,
       modifiedAt: now,
-      curator: curatorData.id,
-      indicatedBy,
+      curator: Number(curatorData.id),
+      indicatedBy: Number(indicatedBy),
       blob: `${title} ${company} ${
         curatorData.name
       } ${now.getFullYear()} ${now.getMonth()} ${now.getDay()}`,

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -2,7 +2,7 @@ import { useState, createContext } from "react";
 import { userLogin } from "@services/user";
 
 interface IUser {
-  id: string;
+  id: number;
   name: string;
   image: string;
   roles: string[];
@@ -10,7 +10,7 @@ interface IUser {
 }
 
 const emptyUser: IUser = {
-  id: "",
+  id: null,
   name: "",
   image: "",
   roles: [],

--- a/src/services/company.ts
+++ b/src/services/company.ts
@@ -1,5 +1,5 @@
 export interface ICompany {
-  id: string;
+  id: number;
   name: string;
   logo: string;
   webSite: string;

--- a/src/services/company.ts
+++ b/src/services/company.ts
@@ -8,7 +8,9 @@ export interface ICompany {
 
 export const addCompanyDataInJob = async (jobs) => {
   const companiesId: string[] = jobs.map((job) => job.company);
-  const companiesData: ICompany[] = await getCompaniesData(companiesId);
+  const companiesUniqueId: string[] = [...new Set(companiesId)];
+  console.log({ companiesUniqueId });
+  const companiesData: ICompany[] = await getCompaniesData(companiesUniqueId);
   const jobsWithCompanyData = jobs.map((job) => ({
     ...job,
     companyData: companiesData.find((company) => company.id === job.company),
@@ -21,7 +23,7 @@ export const getCompaniesData = async (companiesId: string[]) => {
     (companyId: string) => `id=${companyId}&`
   );
   const companiesQueryUrl = `?${companiesQuery.join("").slice(0, -1)}`; //Slice remove the  last "&'
-  console.log(companiesQueryUrl);
+
   try {
     const res = await fetch(
       `http://localhost:4000/companies${companiesQueryUrl}`

--- a/src/services/job.ts
+++ b/src/services/job.ts
@@ -1,5 +1,22 @@
 import { addCompanyDataInJob } from "./company";
 
+export interface IJob {
+  title: string;
+  company: number;
+  description: string;
+  location: string;
+  requisites: string[];
+  stack: string[];
+  url: string;
+  source: string;
+  status: "open" | "closed";
+  createAt: Date;
+  modifiedAt: Date;
+  curator: number;
+  indicatedBy: number;
+  blob: string;
+}
+
 export const getRecentJobs = async () => {
   try {
     const res = await fetch(
@@ -7,6 +24,7 @@ export const getRecentJobs = async () => {
     );
     if (res.ok) {
       const data = await res.json();
+
       const jobsWithCompanyData = await addCompanyDataInJob(data);
 
       const dataSanitized = jobsWithCompanyData.map((job) => ({
@@ -25,7 +43,7 @@ export const getRecentJobs = async () => {
   }
 };
 
-export const createJob = async (data) => {
+export const createJob = async (data: IJob) => {
   try {
     const res = await fetch(`http://localhost:4000/jobs`, {
       method: "POST",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Resolvendo o bug de ao dar cadastrar nova vaga, quebrava o site de vagas.

Eram basicamente dois errros:
- É possível terem vagas da mesma empresa, então no service de pegar os IDs das companhias tem que tirar os repetidos (pra query não ter IDs repetidos, o que dá erro)

- Erro de tipo no formulário, o id estava sendo passado como string e os outros do BD eram números. Pra resolver isso passei todos os IDs para número e dei uma reforçada no TypeScript (mas ainda não acho q ficou 100%, pq tinha hora que devia estar acusando erro e não acusou eu acho)